### PR TITLE
APICast Nginx module - Initial bootstrap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM centos:8
+
+RUN yum upgrade -y \
+    && dnf install -y 'dnf-command(config-manager)' \
+    && yum config-manager --add-repo http://packages.dev.3sca.net/dev_packages_3sca_net.repo \
+    && dnf --enablerepo=PowerTools install -y perl-List-MoreUtils perl-Test-LongString libyaml-devel\
+    && yum install -y \
+        gcc make git which curl expat-devel \
+        perl-Test-Nginx openssl-devel m4 \
+        perl-local-lib perl-App-cpanminus \
+        libyaml wget vim valgrind pcre-devel
+
+
+WORKDIR /opt/
+COPY Makefile /opt/
+WORKDIR /opt/
+RUN make download

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+BUILD=build
+
+createFolder:
+	mkdir $(BUILD)
+
+clean:
+	rm -r $(BUILD) | exit 0
+
+download: clean createFolder
+	wget https://openresty.org/download/openresty-1.15.8.2.tar.gz -O  $(BUILD)/openresty.tar.gz
+	tar xfvz $(BUILD)/openresty.tar.gz -C $(BUILD)
+
+#./configure --add-module=/opt/ --with-cc-opt="-I/opt/" --with-ld-opt="-L/opt/"
+# make
+# make install

--- a/config
+++ b/config
@@ -1,0 +1,6 @@
+ngx_module_type=HTTP
+ngx_addon_name=apicast
+ngx_module_name=ngx_http_apicast_module
+ngx_module_srcs="$ngx_addon_dir/ngx_http_apicast_module.c"
+
+. auto/module

--- a/ngx_http_apicast_module.c
+++ b/ngx_http_apicast_module.c
@@ -1,0 +1,286 @@
+/*
+ * APIcast nginx module
+ */
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_http.h>
+
+typedef struct {
+  X509                *proxy_client_cert;
+  EVP_PKEY            *proxy_client_cert_key;
+  X509_STORE          *proxy_client_ca_store;
+} ngx_http_apiast_ctx_t;
+
+
+static ngx_http_apiast_ctx_t * ngx_http_apicast_set_ctx(ngx_http_request_t *r);
+ngx_int_t ngx_http_upstream_secure_connection_handler(
+    ngx_http_request_t *r, ngx_http_upstream_t *u, ngx_connection_t *c);
+
+static ngx_int_t ngx_http_apicast_handler(ngx_http_request_t *r);
+static ngx_int_t ngx_http_apicast_init(ngx_conf_t *cf);
+
+static ngx_command_t  ngx_http_apicast_commands[] = {
+};
+
+static ngx_http_module_t  ngx_http_apicast_module_ctx = {
+  NULL,                                  /* preconfiguration */
+  ngx_http_apicast_init,               /* postconfiguration */
+
+  NULL,                                  /* create main configuration */
+  NULL,                                  /* init main configuration */
+
+  NULL,                                  /* create server configuration */
+  NULL,                                  /* merge server configuration */
+
+  NULL,    /* create location configuration */
+  NULL,      /* merge location configuration */
+};
+
+
+ngx_module_t  ngx_http_apicast_module = {
+  NGX_MODULE_V1,
+  &ngx_http_apicast_module_ctx,        /* module context */
+  ngx_http_apicast_commands,           /* module directives */
+  NGX_HTTP_MODULE,                       /* module type */
+  NULL,                                  /* init master */
+  NULL,                                  /* init module */
+  NULL,                                  /* init process */
+  NULL,                                  /* init thread */
+  NULL,                                  /* exit thread */
+  NULL,                                  /* exit process */
+  NULL,                                  /* exit master */
+  NGX_MODULE_V1_PADDING
+};
+
+static ngx_http_apiast_ctx_t * ngx_http_apicast_set_ctx(ngx_http_request_t *r) {
+  ngx_http_apiast_ctx_t *ctx;
+
+  // @TODO maybe we need to clean this memory
+  ctx = ngx_pcalloc(r->pool, sizeof(ngx_http_apiast_ctx_t));
+  if (ctx == NULL) {
+    return NULL;
+  }
+
+  ngx_http_set_ctx(r, ctx, ngx_http_apicast_module);
+  return ctx;
+}
+
+static ngx_int_t ngx_http_apicast_handler(ngx_http_request_t *r) {
+  // @TODO validate here that the ctx is deleted and it's not leaking
+  ngx_http_apicast_set_ctx(r);
+  return NGX_OK;
+}
+
+int ngx_http_apicast_ffi_set_proxy_cert_key(
+    ngx_http_request_t *r, void *cdata_chain, void *cdata_key) {
+
+  char *err = "";
+  STACK_OF(X509) *cert_chain = cdata_chain;
+  EVP_PKEY *cert_key = cdata_key;
+
+  if ( cert_chain == NULL || cert_key == NULL ) {
+    err = "No valid cert or key was received";
+    goto failed;
+  }
+
+  ngx_http_apiast_ctx_t *ctx;
+  ctx = ngx_http_get_module_ctx(r, ngx_http_apicast_module);
+
+  if (ctx == NULL) {
+    err = "Context cannot be retrieved";
+    goto failed;
+  }
+
+  if (sk_X509_num(cert_chain) < 1) {
+    err = "Invalid certificate chain";
+    goto failed;
+  }
+
+  X509 *x509 = NULL;
+  x509 = sk_X509_value(cert_chain, 0);
+  if (x509 == NULL) {
+    err = "sk_X509_value() failed";
+    goto failed;
+  }
+
+	if (EVP_PKEY_up_ref(cert_key) == 0) {
+		ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+			"EVP_PKEY_up_ref: failed to increment key");
+		return NGX_ERROR;
+	}
+
+  ctx->proxy_client_cert = x509;
+  ctx->proxy_client_cert_key = cert_key;
+  return NGX_OK;
+
+failed:
+  ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+    "set_proxy_cert: %s", err);
+  return NGX_ERROR;
+}
+
+int ngx_http_apicast_ffi_set_proxy_ca_cert(
+    ngx_http_request_t *r, void *cdata_ca) {
+  X509_STORE  *ca_store = cdata_ca;
+
+  if ( ca_store == NULL)
+    return NGX_ERROR;
+
+  ngx_http_apiast_ctx_t *ctx;
+  ctx = ngx_http_get_module_ctx(r, ngx_http_apicast_module);
+
+  if (ctx == NULL)
+    return NGX_ERROR;
+
+  if (X509_STORE_up_ref(ca_store) == 0) {
+    ngx_log_error(NGX_LOG_WARN, r->connection->log, 0,
+      "SetProxyCaCert: cannot set the store ref");
+    return NGX_ERROR;
+  }
+  ctx->proxy_client_ca_store = ca_store;
+  return NGX_OK;
+}
+
+
+ngx_int_t ngx_http_apicast_set_proxy_cert_if_set(
+    ngx_http_request_t *r, ngx_http_apiast_ctx_t *ctx, ngx_connection_t *conn) {
+
+  char *err = "";
+
+  if ( ctx == NULL ) {
+    err = "No context found";
+    goto ssl_failed;
+  }
+
+  if ( ctx->proxy_client_cert == NULL ) {
+    ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0,
+      "SetProxyCert: no certificate was set");
+    return NGX_OK;
+  }
+
+  int rc = SSL_use_certificate(conn->ssl->connection, ctx->proxy_client_cert);
+  if ( rc == 0 ) {
+      err = "SSL_USE_certificate failed";
+      goto ssl_failed;
+  }
+  return NGX_OK;
+
+ssl_failed:
+  ERR_print_errors_fp(stderr);
+  ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+    "SetProxyCert: %s", err);
+  ERR_clear_error();
+  return NGX_ERROR;
+}
+
+ngx_int_t ngx_http_apicast_set_proxy_cert_key_if_set(
+    ngx_http_request_t *r,
+    ngx_http_apiast_ctx_t *ctx,
+    ngx_connection_t *conn) {
+  if (ctx == NULL) {
+    return NGX_ERROR;
+  }
+
+  if ( ctx->proxy_client_cert_key == NULL ) {
+    ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0,
+      "SetProxyCertKey: certificate key was not found");
+    return NGX_OK;
+  }
+
+  int rc = SSL_use_PrivateKey(
+      conn->ssl->connection,
+      ctx->proxy_client_cert_key);
+
+  if ( rc == 0 ) {
+		EVP_PKEY_free(ctx->proxy_client_cert_key);
+    ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+      "SetProxyCertKey: cannot use certificate key, rc:'%d'", rc);
+    ERR_print_errors_fp(stderr);
+    ERR_clear_error();
+    return NGX_ERROR;
+  }
+
+  return NGX_OK;
+}
+
+ngx_int_t ngx_http_apicast_set_proxy_ca_cert_if_set(
+    ngx_http_request_t *r,
+    ngx_http_apiast_ctx_t *ctx,
+    ngx_connection_t *conn) {
+
+  if ( ctx == NULL ) {
+    return NGX_ERROR;
+  }
+
+  if ( ctx->proxy_client_ca_store == NULL ) {
+    return NGX_OK;
+  }
+
+  int rc = SSL_set1_verify_cert_store(
+      conn->ssl->connection,
+      ctx->proxy_client_ca_store);
+  if ( rc == 0 ) {
+    ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+      "Cannot set the ca cert to the store, rc:%d", rc);
+    return NGX_ERROR;
+  }
+
+  return NGX_OK;
+}
+
+// @TODO vetify, verifydepth and session reuse
+ngx_int_t ngx_http_upstream_secure_connection_handler(
+    ngx_http_request_t *r, ngx_http_upstream_t *u, ngx_connection_t *c) {
+
+  ngx_http_apiast_ctx_t *ctx;
+  char *err = "";
+  ctx = ngx_http_get_module_ctx(r, ngx_http_apicast_module);
+
+  ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0,
+    "Connection Handler started for request:'%p' and ctx:'%p'", r, ctx);
+  if ( ctx == NULL ) {
+    err = "Handler:: no context found";
+    goto ssl_failed;
+  }
+
+  if ( ngx_http_apicast_set_proxy_cert_if_set(r, ctx, c) != NGX_OK ) {
+    err = "SetCert:: cannot set proxy_cert";
+    goto ssl_failed;
+  }
+
+  if ( ngx_http_apicast_set_proxy_cert_key_if_set(r, ctx, c) != NGX_OK ) {
+    err = "SetPrivatekey:: cannot set proxy key";
+    goto ssl_failed;
+  }
+
+  if ( ngx_http_apicast_set_proxy_ca_cert_if_set(r, ctx, c) != NGX_OK ) {
+    err = "SetPrivatekey:: cannot set CA certs";
+    goto ssl_failed;
+  }
+
+  return NGX_OK;
+
+ssl_failed:
+  ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+    "Connection Handler: %s", err);
+  ERR_clear_error();
+  return NGX_ERROR;
+}
+
+static ngx_int_t ngx_http_apicast_init(ngx_conf_t *cf) {
+
+  ngx_http_handler_pt        *h;
+  ngx_http_core_main_conf_t  *cmcf;
+
+  cmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_core_module);
+
+  h = ngx_array_push(&cmcf->phases[NGX_HTTP_ACCESS_PHASE].handlers);
+  if ( h == NULL ) {
+    return NGX_ERROR;
+  }
+
+  *h = ngx_http_apicast_handler;
+
+  return NGX_OK;
+}

--- a/ngx_http_apicast_module.h
+++ b/ngx_http_apicast_module.h
@@ -1,0 +1,5 @@
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_http.h>
+
+ngx_int_t ngx_http_upstream_secure_connection_handler(ngx_http_request_t *r, ngx_http_upstream_t *u, ngx_connection_t *c);

--- a/test/access.lua
+++ b/test/access.lua
@@ -1,0 +1,44 @@
+local ssl = require('ngx.ssl')
+local open = io.open
+local ffi = require "ffi"
+local C = ffi.C
+local base = require "resty.core.base"
+local get_request = base.get_request
+
+local function set_certs(cert, key)
+  ngx.log(ngx.INFO, "Try to set certs")
+  ffi.cdef[[
+  int ngx_http_apicast_ffi_set_proxy_cert_key(
+    ngx_http_request_t *r, void *cdata_chain, void *cdata_key);
+  ]]
+  local r = get_request()
+    if not r then
+      ngx.log(ngx.ERR, "No valid request")
+      return
+    end
+   C.ngx_http_apicast_ffi_set_proxy_cert_key(r, cert, key)
+
+end
+
+local function read_file(path)
+    local file = open(path, "rb") -- r read mode and b binary mode
+    if not file then return nil end
+    local content = file:read "*a" -- *a or *all reads the whole file
+    file:close()
+    return content
+end
+
+local cert =  read_file("/secrets/client.cer")
+local cert_key =  read_file("/secrets/client.key")
+
+local cert_chain, err = ssl.parse_pem_cert(cert)
+if err then
+  ngx.log(ngx.ERR, "Unable to parse cer")
+end
+
+local priv_key, err = ssl.parse_pem_priv_key(cert_key)
+if err then
+  ngx.log(ngx.ERR, "Unable to parse cer key")
+end
+
+set_certs(cert_chain, priv_key)

--- a/test/mtls.conf
+++ b/test/mtls.conf
@@ -1,0 +1,23 @@
+worker_processes  1;
+master_process off;
+daemon off;
+error_log /dev/stdout error;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  server {
+    listen 8000;
+
+    location / {
+
+      access_by_lua_file /opt/build/access.lua;
+      resolver 8.8.8.8;
+
+      proxy_pass https://mtls-server.cluster.local:8043/;
+      proxy_http_version 1.1;
+    }
+  }
+}


### PR DESCRIPTION
This module adds support to enable upstream client certificates, to
store the certificates in each request and avoid the need to use
proxy_client_certificate_*

The FFI functions that are exported:

```
ngx_http_apicast_ffi_set_proxy_cert_key
ngx_http_apicast_ffi_set_proxy_ca_cert
```

The Upstream code will call to a connection handler, that will update
SSL certificates that are in use.

```
ngx_http_upstream_secure_connection_handler
```

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>