### PR TITLE
Enable chain client certs

### DIFF
--- a/create-intermediate-certs.sh
+++ b/create-intermediate-certs.sh
@@ -41,11 +41,11 @@ openssl x509 -req -in subCA.req \
   -CA rootCA.pem -CAkey rootCA.key -CAcreateserial \
   -extfile ca_config.cfg \
   -extensions v3_ca \
-  -out bundleCA.crt
+  -out intermediateCA.crt
 
 echo ">> Verify Intermediate CA"
-openssl verify -CAfile rootCA.pem bundleCA.crt
-openssl x509 -in bundleCA.crt -noout -purpose
+openssl verify -CAfile rootCA.pem intermediateCA.crt
+openssl x509 -in intermediateCA.crt -noout -purpose
 
 
 echo ">> SSL listen certificates"
@@ -61,8 +61,8 @@ echo ">> SSL create client cert"
 openssl genrsa -out client.key 4096
 openssl req -new -subj '/CN=test' -key client.key -out client.req
 openssl x509 -req -in client.req \
-  -CA bundleCA.crt -CAkey subCA.key \
+  -CA intermediateCA.crt -CAkey subCA.key \
   -CAcreateserial -out client.crt \
   -days 500 -sha256
 
-cat client.crt bundleCA.crt rootCA.pem > client_bundle.crt
+cat client.crt intermediateCA.crt rootCA.pem > client_chain.crt

--- a/create-intermediate-certs.sh
+++ b/create-intermediate-certs.sh
@@ -1,0 +1,68 @@
+echo "*****************  Certs creation  *************************"
+
+function echo {
+  COLOR="\e[93m";
+  ENDCOLOR="\e[0m";
+  printf "$COLOR%b$ENDCOLOR\n" "$1";
+}
+
+export CERT_FOLDER="$(pwd)/certs"
+export DOMAIN="subca.acalustra.com"
+
+mkdir -p $CERT_FOLDER
+rm -rf $CERT_FOLDER/*
+cd $CERT_FOLDER
+
+echo "Certs creation on folder: $CERT_FOLDER"
+
+echo ">> SSL create CA cert"
+openssl genrsa -out rootCA.key 4096
+openssl req -batch -new -x509 -nodes -subj "/CN=root.ca" \
+  -extensions v3_ca \
+  -key rootCA.key -sha256 -days 1024 -out rootCA.pem
+
+echo ">> Intermediate  CA cert"
+openssl genrsa -out subCA.key 4096
+openssl req -batch -new -x509 -subj "/CN=sub.ca" -nodes \
+  -extensions v3_ca \
+  -key subCA.key -sha256 -days 1024 -out subCA.pem
+
+echo ">> Intermediate CA sign by RootCA"
+
+cat <<EOF > ca_config.cfg
+[ v3_ca ]
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid:always,issuer
+basicConstraints = critical,CA:true
+EOF
+openssl x509 -x509toreq -days 365 -in subCA.pem -signkey subCA.key -out subCA.req
+openssl x509 -req -in subCA.req \
+  -days 500 -sha256 \
+  -CA rootCA.pem -CAkey rootCA.key -CAcreateserial \
+  -extfile ca_config.cfg \
+  -extensions v3_ca \
+  -out bundleCA.crt
+
+echo ">> Verify Intermediate CA"
+openssl verify -CAfile rootCA.pem bundleCA.crt
+openssl x509 -in bundleCA.crt -noout -purpose
+
+
+echo ">> SSL listen certificates"
+openssl req -subj "/CN=$DOMAIN"  -newkey rsa:4096 -nodes \
+		-sha256 \
+		-days 3650 \
+		-keyout $DOMAIN.key \
+		-out $DOMAIN.csr
+openssl x509 -req -in $DOMAIN.csr -CA rootCA.pem -CAkey rootCA.key -CAcreateserial -out $DOMAIN.crt -days 500 -sha256
+
+
+echo ">> SSL create client cert"
+openssl genrsa -out client.key 4096
+openssl req -new -subj '/CN=test' -key client.key -out client.req
+openssl x509 -req -in client.req \
+  -CA bundleCA.crt -CAkey subCA.key \
+  -CAcreateserial -out client.crt \
+  -days 500 -sha256
+
+cat client.crt bundleCA.crt rootCA.pem > client_bundle.crt

--- a/ngx_http_apicast_module.c
+++ b/ngx_http_apicast_module.c
@@ -13,10 +13,10 @@ typedef struct {
   X509_STORE          *proxy_client_ca_store;
   int                 proxy_ssl_verify;
   int                 proxy_ssl_verify_depth;
-} ngx_http_apiast_ctx_t;
+} ngx_http_apicast_ctx_t;
 
 
-static ngx_http_apiast_ctx_t * ngx_http_apicast_set_ctx(ngx_http_request_t *r);
+static ngx_http_apicast_ctx_t * ngx_http_apicast_set_ctx(ngx_http_request_t *r);
 ngx_int_t ngx_http_upstream_secure_connection_handler(
     ngx_http_request_t *r, ngx_http_upstream_t *u, ngx_connection_t *c);
 
@@ -57,13 +57,13 @@ ngx_module_t  ngx_http_apicast_module = {
   NGX_MODULE_V1_PADDING
 };
 
-static ngx_http_apiast_ctx_t * ngx_http_apicast_set_ctx(ngx_http_request_t *r) {
+static ngx_http_apicast_ctx_t * ngx_http_apicast_set_ctx(ngx_http_request_t *r) {
 
-  ngx_http_apiast_ctx_t *ctx;
+  ngx_http_apicast_ctx_t *ctx;
   ngx_pool_cleanup_t  *cln;
 
   // @TODO maybe we need to clean this memory
-  ctx = ngx_pcalloc(r->pool, sizeof(ngx_http_apiast_ctx_t));
+  ctx = ngx_pcalloc(r->pool, sizeof(ngx_http_apicast_ctx_t));
   if (ctx == NULL) {
     return NULL;
   }
@@ -103,7 +103,7 @@ int ngx_http_apicast_ffi_set_proxy_cert_key(
     goto failed;
   }
 
-  ngx_http_apiast_ctx_t *ctx;
+  ngx_http_apicast_ctx_t *ctx;
   ctx = ngx_http_get_module_ctx(r, ngx_http_apicast_module);
 
   if (ctx == NULL) {
@@ -174,7 +174,7 @@ int ngx_http_apicast_ffi_set_proxy_ca_cert(
   if ( ca_store == NULL)
     return NGX_ERROR;
 
-  ngx_http_apiast_ctx_t *ctx;
+  ngx_http_apicast_ctx_t *ctx;
   ctx = ngx_http_get_module_ctx(r, ngx_http_apicast_module);
 
   if (ctx == NULL)
@@ -190,7 +190,7 @@ int ngx_http_apicast_ffi_set_proxy_ca_cert(
 }
 
 int ngx_http_apicast_ffi_set_ssl_verify(ngx_http_request_t *r, int verify, int verify_deph){
-  ngx_http_apiast_ctx_t *ctx;
+  ngx_http_apicast_ctx_t *ctx;
   ctx = ngx_http_get_module_ctx(r, ngx_http_apicast_module);
 
   if (ctx == NULL)
@@ -203,7 +203,7 @@ int ngx_http_apicast_ffi_set_ssl_verify(ngx_http_request_t *r, int verify, int v
 
 
 ngx_int_t ngx_http_apicast_set_proxy_cert_if_set(
-    ngx_http_request_t *r, ngx_http_apiast_ctx_t *ctx, ngx_connection_t *conn) {
+    ngx_http_request_t *r, ngx_http_apicast_ctx_t *ctx, ngx_connection_t *conn) {
 
   char *err = "";
 
@@ -248,7 +248,7 @@ ssl_failed:
 
 ngx_int_t ngx_http_apicast_set_proxy_cert_key_if_set(
     ngx_http_request_t *r,
-    ngx_http_apiast_ctx_t *ctx,
+    ngx_http_apicast_ctx_t *ctx,
     ngx_connection_t *conn) {
   if (ctx == NULL) {
     return NGX_ERROR;
@@ -278,7 +278,7 @@ ngx_int_t ngx_http_apicast_set_proxy_cert_key_if_set(
 
 ngx_int_t ngx_http_apicast_set_proxy_ca_cert_if_set(
     ngx_http_request_t *r,
-    ngx_http_apiast_ctx_t *ctx,
+    ngx_http_apicast_ctx_t *ctx,
     ngx_connection_t *conn) {
 
   if ( ctx == NULL ) {
@@ -304,7 +304,7 @@ ngx_int_t ngx_http_apicast_set_proxy_ca_cert_if_set(
 
 ngx_int_t ngx_http_apicast_set_proxy_ssl_verify(
     ngx_http_request_t *r,
-    ngx_http_apiast_ctx_t *ctx,
+    ngx_http_apicast_ctx_t *ctx,
     ngx_connection_t *conn) {
 
   if ( ctx == NULL ) {
@@ -328,7 +328,7 @@ ngx_int_t ngx_http_apicast_set_proxy_ssl_verify(
 ngx_int_t ngx_http_upstream_secure_connection_handler(
     ngx_http_request_t *r, ngx_http_upstream_t *u, ngx_connection_t *c) {
 
-  ngx_http_apiast_ctx_t *ctx;
+  ngx_http_apicast_ctx_t *ctx;
   char *err = "";
   ctx = ngx_http_get_module_ctx(r, ngx_http_apicast_module);
 
@@ -388,7 +388,7 @@ static ngx_int_t ngx_http_apicast_init(ngx_conf_t *cf) {
 void
 ngx_http_apicast_ssl_cleanup_ctx(void *data)
 {
-  ngx_http_apiast_ctx_t *ctx = data;
+  ngx_http_apicast_ctx_t *ctx = data;
 
   if (ctx->proxy_client_cert_chain) {
     sk_X509_pop_free(ctx->proxy_client_cert_chain, X509_free);

--- a/test/mtls.conf
+++ b/test/mtls.conf
@@ -1,7 +1,7 @@
 worker_processes  1;
 master_process off;
 daemon off;
-error_log /dev/stdout error;
+error_log /dev/stdout debug;
 
 events {
   worker_connections 1024;
@@ -9,47 +9,53 @@ events {
 
 http {
 
-  server {
-    listen 8080;
-
-    location / {
-
-      access_by_lua_file /opt/test/access.lua;
-      # resolver 8.8.8.8;
-
-      proxy_pass https://127.0.0.1:8043/;
-      proxy_ssl_name test.com;
+    init_by_lua_block {
+      mtls = require("mtls")
+      mtls:init()
     }
-  }
 
+    server {
+      listen 8080;
+      location / {
+        access_by_lua_block {
+          mtls:access()
+        }
 
-  server {
-    listen 8081;
-
-    location / {
-      proxy_pass https://127.0.0.1:8043/;
-      proxy_ssl_name test.com;
-      proxy_ssl_certificate /opt/certs/client.crt;
-      proxy_ssl_certificate_key /opt/certs/client.key;
-      proxy_ssl_trusted_certificate /opt/certs/rootCA.pem;
-      proxy_http_version 1.1;
-      proxy_ssl_verify on;
-      proxy_ssl_verify_depth 2;
+       proxy_pass https://127.0.0.1:8043/;
+       proxy_ssl_name subca.acalustra.com;
+       proxy_ssl_server_name on;
+       proxy_ssl_verify_depth 100;
+      }
     }
-  }
+
+   server {
+     listen 8081;
+
+     location / {
+       proxy_pass https://127.0.0.1:8043/;
+       proxy_ssl_name subca.acalustra.com;
+       proxy_ssl_certificate /opt/certs/client_bundle.crt;
+       proxy_ssl_certificate_key /opt/certs/client.key;
+       proxy_ssl_trusted_certificate /opt/certs/rootCA.pem;
+       proxy_http_version 1.1;
+       proxy_ssl_verify on;
+       proxy_ssl_verify_depth 100;
+     }
+   }
 
   server {
     listen 8043 ssl;
 
-    ssl_certificate /opt/certs/test.com.crt;
-    ssl_certificate_key /opt/certs/test.com.key;
+    ssl_certificate /opt/certs/subca.acalustra.com.crt;
+    ssl_certificate_key /opt/certs/subca.acalustra.com.key;
 
     ssl_client_certificate /opt/certs/rootCA.pem;
     ssl_verify_client on;
+    ssl_verify_depth 1000;
 
     location / {
-      return 200 'gangnam style!';
+      echo 'ssl_client_s_dn: \$ssl_client_s_dn';
+      echo 'ssl_client_i_dn: \$ssl_client_i_dn';
     }
   }
-
 }

--- a/test/mtls.conf
+++ b/test/mtls.conf
@@ -34,7 +34,7 @@ http {
      location / {
        proxy_pass https://127.0.0.1:8043/;
        proxy_ssl_name subca.acalustra.com;
-       proxy_ssl_certificate /opt/certs/client_bundle.crt;
+       proxy_ssl_certificate /opt/certs/client_chain.crt;
        proxy_ssl_certificate_key /opt/certs/client.key;
        proxy_ssl_trusted_certificate /opt/certs/rootCA.pem;
        proxy_http_version 1.1;

--- a/test/mtls.lua
+++ b/test/mtls.lua
@@ -1,0 +1,99 @@
+local ssl = require('ngx.ssl')
+local open = io.open
+local ffi = require "ffi"
+local C = ffi.C
+local base = require "resty.core.base"
+local get_request = base.get_request
+local ssl_store = require("resty.openssl.x509.store")
+local x509 = require("resty.openssl.x509")
+
+_M = {}
+
+ffi.cdef[[
+  int ngx_http_apicast_ffi_set_proxy_cert_key(
+    ngx_http_request_t *r, void *cdata_chain, void *cdata_key);
+
+  int ngx_http_apicast_ffi_set_proxy_ca_cert(
+    ngx_http_request_t *r, void *cdata_ca);
+
+  int ngx_http_apicast_ffi_set_ssl_verify(
+    ngx_http_request_t *r, int verify, int verify_deph);
+]]
+
+local function set_certs(cert, key)
+  ngx.log(ngx.INFO, "Try to set certs")
+
+  local r = get_request()
+    if not r then
+      ngx.log(ngx.ERR, "No valid request")
+      return
+    end
+   C.ngx_http_apicast_ffi_set_proxy_cert_key(r, cert, key)
+
+end
+
+local function set_ca(store)
+  ngx.log(ngx.INFO, "Try to set CA certs")
+
+  local r = get_request()
+  if not r then
+    ngx.log(ngx.ERR, "No valid request")
+    return
+  end
+
+  C.ngx_http_apicast_ffi_set_proxy_ca_cert(r, store.ctx)
+end
+
+local function set_ffi_verify()
+  ngx.log(ngx.INFO, "Try to set verify")
+
+  local r = get_request()
+  if not r then
+    ngx.log(ngx.ERR, "No valid request")
+    return
+  end
+
+  C.ngx_http_apicast_ffi_set_ssl_verify(r, ffi.new("int", 100), ffi.new("int", 100))
+end
+
+local function read_file(path)
+    local file = open(path, "rb") -- r read mode and b binary mode
+    if not file then return nil end
+    local content = file:read "*a" -- *a or *all reads the whole file
+    file:close()
+    return content
+end
+
+
+
+function _M:init()
+  local err = nil
+
+  local cert =  read_file("/opt/certs/client_bundle.crt")
+  local cert_key =  read_file("/opt/certs/client.key")
+  local ca_cert =  read_file("/opt/certs/rootCA.pem")
+
+  self.cert_chain, err = ssl.parse_pem_cert(cert)
+  if err then
+    ngx.log(ngx.ERR, "Unable to parse cer")
+  end
+
+  self.priv_key, err = ssl.parse_pem_priv_key(cert_key)
+  if err then
+    ngx.log(ngx.ERR, "Unable to parse cer key")
+  end
+
+  local store = ssl_store.new()
+
+  store:add(x509.new(ca_cert))
+
+  self.ca_store = store
+end
+
+function _M:access()
+  set_certs(self.cert_chain, self.priv_key)
+  set_ca(self.ca_store)
+  set_ffi_verify()
+end
+
+return _M

--- a/test/mtls.lua
+++ b/test/mtls.lua
@@ -69,7 +69,7 @@ end
 function _M:init()
   local err = nil
 
-  local cert =  read_file("/opt/certs/client_bundle.crt")
+  local cert =  read_file("/opt/certs/client_chain.crt")
   local cert_key =  read_file("/opt/certs/client.key")
   local ca_cert =  read_file("/opt/certs/rootCA.pem")
 


### PR DESCRIPTION
When using a intermediate cert, the intermediate CA should be appended
to the client cert to allow the server to verify the signature.

Before we only used the first certificate, so things were not working
correctly.

This patched changes a bit the nginx module, plus added a few test
scripts.

Integration test to be made on APICast QE testsuite.

Fix https://issues.redhat.com/browse/THREESCALE-7363

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>