### PR TITLE
Adding a helper function to check if should be verified.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,14 @@ RUN yum upgrade -y \
         gcc make git which curl expat-devel \
         perl-Test-Nginx openssl-devel m4 \
         perl-local-lib perl-App-cpanminus \
-        libyaml wget vim valgrind pcre-devel
-
+        libyaml wget vim valgrind pcre-devel patch
 
 WORKDIR /opt/
+
 COPY Makefile /opt/
-WORKDIR /opt/
+COPY patches/ /opt/patches/
 RUN make download
+COPY ngx_http_apicast_module.* /opt/
+COPY config /opt/
+RUN make patch
+RUN make compile

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 BUILD=build
+OPENRESTY_VERSION=1.19.3.1
 
 createFolder:
 	mkdir $(BUILD)
@@ -7,11 +8,19 @@ clean:
 	rm -r $(BUILD) | exit 0
 
 download: clean createFolder
-	wget https://openresty.org/download/openresty-1.19.3.1.tar.gz -O  $(BUILD)/openresty.tar.gz
+	wget https://openresty.org/download/openresty-$(OPENRESTY_VERSION).tar.gz -O  $(BUILD)/openresty.tar.gz
 	tar xfvz $(BUILD)/openresty.tar.gz -C $(BUILD)
 
-#./configure --add-module=/opt/ --with-cc-opt="-I/opt/" --with-ld-opt="-L/opt/"
-# make
-# make install
-#
+patch:
+	patch -p0 < patches/nginx_upstream.diff
 
+compile:
+	cd build/openresty-$(OPENRESTY_VERSION) && \
+	./configure --with-cc-opt="-I/opt/" --with-ld-opt="-L/opt/" --add-module="/opt/" && \
+	make && \
+	make install
+
+openssl:
+	 cd /tmp && \
+	 git clone https://github.com/fffonion/lua-resty-openssl.git --depth 1 && \
+	 cp lua-resty-openssl/lib/resty/openssl /usr/local/openresty/lualib/resty -R /

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # apicast-nginx-module
+
+Custom Nginx module that adds a few options to be able to run some special
+operations on top of Openresty.
+
+## Build
+
+Create docker image
+```
+docker build -t 3scale/apicast-nginx-module .
+```
+
+This module needs some updates on nginx code, all of them appended on patches/
+
+## Examples:
+
+**test/mtls.conf:**
+Example of upstream MTLs where the certs can be set on init/access phase.
+
+# Testing:
+All made on APICast project

--- a/ngx_http_apicast_module.c
+++ b/ngx_http_apicast_module.c
@@ -324,6 +324,20 @@ ngx_int_t ngx_http_apicast_set_proxy_ssl_verify(
   return NGX_OK;
 }
 
+ngx_int_t ngx_http_upstream_should_verified(ngx_http_request_t *r) {
+
+  ngx_http_apicast_ctx_t *ctx;
+
+  ctx = ngx_http_get_module_ctx(r, ngx_http_apicast_module);
+  if (ctx == NULL ) {
+    return NGX_ERROR;
+  }
+
+  if (ctx->proxy_ssl_verify > 0) {
+    return NGX_OK;
+  }
+  return NGX_ERROR;
+}
 
 ngx_int_t ngx_http_upstream_secure_connection_handler(
     ngx_http_request_t *r, ngx_http_upstream_t *u, ngx_connection_t *c) {

--- a/ngx_http_apicast_module.h
+++ b/ngx_http_apicast_module.h
@@ -3,3 +3,4 @@
 #include <ngx_http.h>
 
 ngx_int_t ngx_http_upstream_secure_connection_handler(ngx_http_request_t *r, ngx_http_upstream_t *u, ngx_connection_t *c);
+ngx_int_t ngx_http_upstream_should_verified(ngx_http_request_t *r);


### PR DESCRIPTION
When handshake happens, we also need to check the CN. Something that
it's not done because u->conf->verify maybe is 0. With this change, a
new function is exported to handle this case on nginx-upstream.

Lines that need to be checked:
https://github.com/nginx/nginx/blob/02bd43d05b6f7803597d8453d9848b767dc4a323/src/http/ngx_http_upstream.c#L1786-L1789

Changes that need to be done on Openresty:
```

static void
ngx_http_upstream_ssl_handshake(ngx_http_request_t *r, ngx_http_upstream_t *u,
    ngx_connection_t *c)
{
    long  rc;

    if (c->ssl->handshaked) {

        if (u->conf->ssl_verify || ngx_http_upstream_should_verified(r) == NGX_OK) {
```

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>